### PR TITLE
Changed default training declaration for TPU

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,7 +7,7 @@ from model import PedalNet
 def main(args):
     model = PedalNet(args)
     trainer = pl.Trainer(
-        max_epochs=args.max_epochs, gpus=args.gpus, row_log_interval=100
+        max_epochs=args.max_epochs, tpu_cores=args.tpu_cores, gpus=args.gpus, row_log_interval=100
     )
     trainer.fit(model)
 
@@ -23,8 +23,9 @@ if __name__ == "__main__":
     parser.add_argument("--learning_rate", type=float, default=3e-3)
 
     parser.add_argument("--max_epochs", type=int, default=1_500)
-    parser.add_argument("--gpus", default="0")
-
+    parser.add_argument("--gpus", default="")
+    parser.add_argument("--tpu_cores", default="8")
+    
     parser.add_argument("--data", default="data.pickle")
     args = parser.parse_args()
     main(args)

--- a/train.py
+++ b/train.py
@@ -7,7 +7,7 @@ from model import PedalNet
 def main(args):
     model = PedalNet(args)
     trainer = pl.Trainer(
-        max_epochs=args.max_epochs, tpu_cores=args.tpu_cores, gpus=args.gpus, row_log_interval=100
+        max_epochs=args.max_epochs, tpu_cores=args.tpu_cores, row_log_interval=100
     )
     trainer.fit(model)
 
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     parser.add_argument("--learning_rate", type=float, default=3e-3)
 
     parser.add_argument("--max_epochs", type=int, default=1_500)
-    parser.add_argument("--gpus", default="")
+    parser.add_argument("--gpus", default="0")
     parser.add_argument("--tpu_cores", default="8")
     
     parser.add_argument("--data", default="data.pickle")


### PR DESCRIPTION
the notebook for colab TPU training doesnt work as is without changing the default for train.py to specify TPU cores instead of searching for GPU